### PR TITLE
refactor: compute test hash from yaml source file

### DIFF
--- a/libs/compiler/src/index.ts
+++ b/libs/compiler/src/index.ts
@@ -2,7 +2,6 @@ import * as fs from "fs";
 import * as path from "path";
 import { runTest } from "@libs/executor";
 import type { TestAPI, GroundingContext } from "@libs/executor";
-import crypto from "crypto";
 import type { GraphNode, TestGraph } from "@libs/domain";
 import { parseTestGraph, loadWorkspace } from "@libs/parser";
 import { getAgentProvider } from "@libs/agents";
@@ -481,24 +480,26 @@ Ensure you address the selector failure or assertion failure correctly. ONLY out
 export async function compile(
   options: CompilerOptions,
 ): Promise<CompileResult> {
-  const content = fs.readFileSync(options.yamlPath, "utf-8");
-  const graphDef = parseTestGraph(content);
+  const ws = await loadWorkspace(options.yamlPath);
+  const testFile = ws.tests.find(
+    (t) => t.filePath === path.resolve(options.yamlPath),
+  );
+  if (!testFile) {
+    throw new Error(`Test file not found in workspace: ${options.yamlPath}`);
+  }
+
+  const graphDef = testFile.getDefinition();
+  const yamlHash = testFile.getHash();
 
   const resolvedPathsList = resolvePaths(graphDef);
   const outputPath =
     options.outputPath || options.yamlPath.replace(".test.yml", ".test.ts");
 
-  // Load workspace config to determine provider and workspace root directory
   let providerName = "gemini-cli";
-  let workspaceDir = process.cwd();
-  try {
-    const ws = await loadWorkspace(options.yamlPath);
-    if (ws.config?.provider?.name) {
-      providerName = ws.config.provider.name;
-    }
-    workspaceDir = path.dirname(ws.provarPath);
-  } catch (err) {
-    // Ignore
+  let workspaceDir = path.dirname(ws.provarPath);
+
+  if (ws.config?.provider?.name) {
+    providerName = ws.config.provider.name;
   }
 
   const agentProvider = getAgentProvider(providerName, {
@@ -636,11 +637,9 @@ export async function compile(
       codeBody +
       testsArray;
 
-    const hash = crypto.createHash("sha256").update(bodyContent).digest("hex");
-
     const fileContent =
       `// date: ${new Date().toISOString()}\n` +
-      `// hash: ${hash}\n` +
+      `// hash: ${yamlHash}\n` +
       bodyContent;
 
     fs.writeFileSync(outputPath, fileContent, "utf-8");

--- a/libs/parser/src/index.ts
+++ b/libs/parser/src/index.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as crypto from "crypto";
 import yaml from "js-yaml";
 import { ConfigSchema, TestGraphSchema } from "@libs/domain";
 import type { Config, TestGraph } from "@libs/domain";
@@ -8,6 +9,7 @@ export interface WorkspaceTest {
   filePath: string;
   relativePath: string;
   getDefinition: () => TestGraph;
+  getHash: () => string;
 }
 
 export interface Workspace {
@@ -95,6 +97,10 @@ export async function loadWorkspace(workspacePath: string): Promise<Workspace> {
           getDefinition: () => {
             const content = fs.readFileSync(fullPath, "utf-8");
             return parseTestGraph(content);
+          },
+          getHash: () => {
+            const content = fs.readFileSync(fullPath, "utf-8");
+            return crypto.createHash("sha256").update(content).digest("hex");
           },
         });
       }


### PR DESCRIPTION
This pull request resolves `TODO-COMPILER-REF002` by ensuring the hash embedded in generated test TypeScript files is derived from the source YAML file content, not the generated TS file.

We updated `WorkspaceTest` in the parser to include a `getHash()` method using `crypto`, and refactored the compiler to load the workspace and use the hash of the source `.test.yml` directly.

---
*PR created automatically by Jules for task [1988371826456801882](https://jules.google.com/task/1988371826456801882) started by @thani-sh*